### PR TITLE
Upgraded references to Serilog 1.5.1

### DIFF
--- a/src/Serilog.Sinks.CouchDB/Serilog.Sinks.CouchDB.nuspec
+++ b/src/Serilog.Sinks.CouchDB/Serilog.Sinks.CouchDB.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging couchdb</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.4.204,2)" />
+      <dependency id="Serilog" version="[1.5.1,2)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.CouchDB/packages.config
+++ b/src/Serilog.Sinks.CouchDB/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Serilog" version="1.5.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes the inability to use Serilog.Sinks.CouchDb with Serilog v1.5.0. 
